### PR TITLE
fix: enable dev buy for non-weth pairs

### DIFF
--- a/src/deployment/v4.ts
+++ b/src/deployment/v4.ts
@@ -157,8 +157,8 @@ export function buildTokenV4(
               msgValue: BigInt(cfg.devBuy.ethAmount * 1e18),
               extensionBps: 0,
               extensionData: encodeAbiParameters(DEVBUY_EXTENSION_PARAMETERS, [
-                DEVBUY_POOL_CONFIG,
-                BigInt(0),
+                cfg.devBuy.poolKey ? cfg.devBuy.poolKey : DEVBUY_POOL_CONFIG,
+                cfg.devBuy.amountOutMin ? BigInt(cfg.devBuy.amountOutMin * 1e18) : BigInt(0),
                 cfg.tokenAdmin,
               ]),
             },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -91,8 +91,18 @@ export interface AirdropConfig {
   percentage: number;
 }
 
+export interface DevBuyPoolKeyConfig {
+  currency0: Address;
+  currency1: Address;
+  fee: number;
+  tickSpacing: number;
+  hooks: Address;
+}
+
 export interface DevBuyConfig {
   ethAmount: number;
+  poolKey?: DevBuyPoolKeyConfig;
+  amountOutMin?: number;
 }
 
 export interface RewardsConfig {

--- a/src/types/v4.ts
+++ b/src/types/v4.ts
@@ -1,6 +1,6 @@
 import { type Address } from 'viem';
 import { type FeeConfig } from './fee.js';
-import { RewardsConfigV4 } from './index.js';
+import { DevBuyPoolKeyConfig, RewardsConfigV4 } from './index.js';
 
 export interface BuildV4Result {
   transaction: {
@@ -45,6 +45,8 @@ export interface TokenConfigV4 {
   };
   devBuy?: {
     ethAmount: number;
+    poolKey?: DevBuyPoolKeyConfig;
+    amountOutMin?: number;
   };
   feeConfig?: FeeConfig;
   lockerConfig?: LockerConfigV4;


### PR DESCRIPTION
This PR enables dev buys for non weth pairs by allowing the user to optionally fill out the needed dev buy params.

An example would be:

```
  .withDevBuy({
                ethAmount: 1,
                // poolkey for USDC<>ETH on Base Mainnet, pool id: 0x96d4b53a38337a5733179751781178a2613306063c511b78cd02684739288c0a
                poolKey: { 
                    currency0: '0x0000000000000000000000000000000000000000',
                    currency1: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
                    fee: 500,
                    tickSpacing: 10,
                    hooks: '0x0000000000000000000000000000000000000000',
                },
                amountOutMin: 0.0000000000000001,
            })
```