### PR TITLE
feat: make user set own positions if using custom price

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clanker-sdk",
-  "version": "4.0.16",
+  "version": "4.0.17",
   "description": "SDK for deploying tokens on Base using Clanker",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,6 +86,7 @@ export enum FeeConfigs {
   DynamicAggressive = 'DynamicAggressive',
 }
 
+// pool positions assuming starting tick of -230400
 export const POOL_POSITIONS = {
   [PoolPositions.Standard]: [
     {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,9 +42,10 @@ export interface TokenConfigV4 {
   vault?: VaultConfigV4;
   airdrop?: AirdropConfig;
   devBuy?: DevBuyConfig;
-  feeConfig?: FeeConfig;
-  rewardsConfig?: RewardsConfigV4;
-  poolConfig?: PoolConfigV4;
+  feeConfig: FeeConfig;
+  rewardsConfig: RewardsConfigV4;
+  poolConfig: PoolConfigV4;
+  lockerConfig: LockerConfigV4;
 }
 
 export interface RewardsConfigV4 {

--- a/src/types/v4.ts
+++ b/src/types/v4.ts
@@ -46,10 +46,10 @@ export interface TokenConfigV4 {
   devBuy?: {
     ethAmount: number;
   };
-  feeConfig?: FeeConfig;
-  lockerConfig?: LockerConfigV4;
-  poolConfig?: PoolConfigV4;
-  rewardsConfig?: RewardsConfigV4;
+  feeConfig: FeeConfig;
+  lockerConfig: LockerConfigV4;
+  poolConfig: PoolConfigV4;
+  rewardsConfig: RewardsConfigV4;
 }
 
 export interface VaultConfigV4 {


### PR DESCRIPTION
The current `PoolPositions.STANDARD/PROJECT` are only for if a token's starting price is `-230_400`.

This PR:
- makes custom prices revert if custom positions are not provided
- enables users to configure the decimals of the input token
- moves the default settings to the `TokenConfigV4.build()` function instead of in the deployment `buildTokenV4()` function
- other small nits/fixes

TODO: review decimal handling with Bryce