### PR TITLE
[Airdrops] Airdrop can now fetch proofs from Clanker service

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clanker-sdk",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "description": "SDK for deploying tokens on Base using Clanker",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/v4/extensions/airdrop.ts
+++ b/src/v4/extensions/airdrop.ts
@@ -113,6 +113,29 @@ export function getAirdropProofs(
 }
 
 /**
+ * Get all proofs for an account given a token that has a merkle tree associated with it. The token and tree must have been registered with the Clanker service.
+ *
+ * @param token The token with the airdrop.
+ * @param account The account to check for.
+ * @returns All proofs and their associated entries for claiming.
+ */
+export async function fetchAirdropProofs(
+  token: `0x${string}`,
+  account: `0x${string}`
+): Promise<{
+  proofs: { proof: `0x${string}`[]; entry: { account: `0x${string}`; amount: bigint } }[];
+}> {
+  return fetch(
+    `https://www.clanker.world/api/airdrops/claim?tokenAddress=${token}&claimerAddress=${account}`
+  ).then(
+    (r) =>
+      r.json() as Promise<{
+        proofs: { proof: `0x${string}`[]; entry: { account: `0x${string}`; amount: bigint } }[];
+      }>
+  );
+}
+
+/**
  * Create a transaction to claim a specific airdrop for.
  *
  * @param token The token that did the airdrop

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     'src/index.ts',
     'src/v3/index.ts',
     'src/v4/index.ts',
+    'src/v4/extensions/index.ts',
     'src/cli/cli.ts',
     'src/cli/create-clanker.ts',
   ],


### PR DESCRIPTION
Also fix bug where the `/extensions` wasn't being exposed