### PR TITLE
Add Robinhood Chain network definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 4.2.17
 - (Chain) Robinhood Chain (chain ID 4663) with official v4 deployment addresses
+- (Bug) Fix CLI deploy chain resolution for Robinhood (`--chain robinhood` no longer defaults to Base)
 - (Bug) Encode ClankerMevDescendingFees init data for Robinhood deploys
 
 4.2.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Clanker SDK - Changelog
 
+4.2.17
+- (Chain) Robinhood Chain network definition (chain ID 4663, RPC, WETH). Clanker deployment pending official contract addresses.
+
 4.2.14
 - (QoL) Vanity address on BSC
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Clanker SDK - Changelog
 
 4.2.17
-- (Chain) Robinhood Chain network definition (chain ID 4663, RPC, WETH). Clanker deployment pending official contract addresses.
+- (Chain) Robinhood Chain (chain ID 4663) with official v4 deployment addresses
 
 4.2.14
 - (QoL) Vanity address on BSC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 4.2.17
 - (Chain) Robinhood Chain (chain ID 4663) with official v4 deployment addresses
+- (Bug) Encode ClankerMevDescendingFees init data for Robinhood deploys
 
 4.2.14
 - (QoL) Vanity address on BSC

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clanker-sdk",
-  "version": "4.2.16",
+  "version": "4.2.17",
   "description": "SDK for deploying tokens using Clanker",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -12,7 +12,7 @@ import {
 import { Clanker as ClankerV3 } from '../../v3/index.js';
 import { createAirdrop } from '../../v4/extensions/airdrop.js';
 import { Clanker as ClankerV4 } from '../../v4/index.js';
-import { CHAIN_NAMES } from '../utils/chains.js';
+import { CHAIN_NAMES, resolveChain } from '../utils/chains.js';
 import {
   blockExplorerUrl,
   printError,
@@ -474,23 +474,17 @@ export function buildV4Config(f: Record<string, unknown>): ClankerTokenV4 {
   return token;
 }
 
-const CHAIN_ID_MAP: Record<string, number> = {
-  base: 8453,
-  'base-sepolia': 84532,
-  arbitrum: 42161,
-  ethereum: 1,
-  bsc: 56,
-  unichain: 130,
-  monad: 143,
-};
-
 export function resolveChainId(name: string): number {
-  return CHAIN_ID_MAP[name] || 8453;
+  try {
+    return resolveChain(name).id;
+  } catch {
+    return 8453;
+  }
 }
 
 function resolveChainName(chainId: number): string {
-  for (const [name, id] of Object.entries(CHAIN_ID_MAP)) {
-    if (id === chainId) return name;
+  for (const name of CHAIN_NAMES) {
+    if (resolveChain(name).id === chainId) return name;
   }
   return 'base';
 }

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -13,6 +13,8 @@ const PUBLIC_RPCS: Record<string, string> = {
   ethereum: 'https://eth.llamarpc.com',
   bsc: 'https://bsc-dataseed.binance.org',
   unichain: 'https://mainnet.unichain.org',
+  robinhood: 'https://rpc.mainnet.chain.robinhood.com',
+  'robinhood-chain': 'https://rpc.mainnet.chain.robinhood.com',
 };
 
 export function registerSetupCommand(program: Command) {

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -14,7 +14,6 @@ const PUBLIC_RPCS: Record<string, string> = {
   bsc: 'https://bsc-dataseed.binance.org',
   unichain: 'https://mainnet.unichain.org',
   robinhood: 'https://rpc.mainnet.chain.robinhood.com',
-  'robinhood-chain': 'https://rpc.mainnet.chain.robinhood.com',
 };
 
 export function registerSetupCommand(program: Command) {

--- a/src/cli/utils/chains.ts
+++ b/src/cli/utils/chains.ts
@@ -1,6 +1,7 @@
 import type { Chain } from 'viem';
 import { arbitrum, base, baseSepolia, bsc, mainnet, unichain } from 'viem/chains';
 import { monad } from '../../utils/chains/monad.js';
+import { robinhood } from '../../utils/chains/robinhood.js';
 
 const CHAIN_MAP: Record<string, Chain> = {
   base,
@@ -10,6 +11,8 @@ const CHAIN_MAP: Record<string, Chain> = {
   bsc,
   unichain,
   monad,
+  robinhood,
+  'robinhood-chain': robinhood,
 };
 
 export const CHAIN_NAMES = Object.keys(CHAIN_MAP);

--- a/src/cli/utils/chains.ts
+++ b/src/cli/utils/chains.ts
@@ -12,7 +12,6 @@ const CHAIN_MAP: Record<string, Chain> = {
   unichain,
   monad,
   robinhood,
-  'robinhood-chain': robinhood,
 };
 
 export const CHAIN_NAMES = Object.keys(CHAIN_MAP);

--- a/src/config/clankerTokenV4.ts
+++ b/src/config/clankerTokenV4.ts
@@ -405,15 +405,16 @@ export const clankerTokenV4Converter: ClankerTokenConverter<
         },
         mevModuleConfig: {
           mevModule: clankerConfig.related?.mevModuleV2 || clankerConfig.related?.mevModule,
-          mevModuleData: clankerConfig.related?.mevModuleV2
-            ? encodeAbiParameters(Clanker_MevSniperAuction_InitData_v4_1_abi, [
-                {
-                  startingFee: cfg.sniperFees.startingFee,
-                  endingFee: cfg.sniperFees.endingFee,
-                  secondsToDecay: BigInt(cfg.sniperFees.secondsToDecay),
-                },
-              ])
-            : '0x',
+          mevModuleData:
+            clankerConfig.related?.mevModuleV2 || clankerConfig.related?.mevDescendingFees
+              ? encodeAbiParameters(Clanker_MevSniperAuction_InitData_v4_1_abi, [
+                  {
+                    startingFee: cfg.sniperFees.startingFee,
+                    endingFee: cfg.sniperFees.endingFee,
+                    secondsToDecay: BigInt(cfg.sniperFees.secondsToDecay),
+                  },
+                ])
+              : '0x',
         },
         extensionConfigs: [
           // vaulting extension

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,7 @@ import {
 } from 'viem/chains';
 import type { ClankerTokenV4 } from './config/clankerTokenV4.js';
 import { monad } from './utils/chains/monad.js';
+import { ROBINHOOD_WETH_ADDRESS, robinhood } from './utils/chains/robinhood.js';
 import type { Chain } from './utils/clankers.js';
 
 export const DEGEN_ADDRESS: `0x${string}` = '0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed';
@@ -36,6 +37,7 @@ export const WETH_ADDRESSES: Record<Chain, `0x${string}`> = {
   [abstract.id]: '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
   [monadTestnet.id]: '0x760AfE86e5de5fa0Ee542fc7B7B713e1c5425701', // WMON
   [monad.id]: '0x3bd359c1119da7da1d913d1c4d2b7c461115433a',
+  [robinhood.id]: ROBINHOOD_WETH_ADDRESS,
 };
 
 export const DEFAULT_SUPPLY = 100_000_000_000_000_000_000_000_000_000n;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,11 @@ export type { ClankerTokenV4 } from './config/clankerTokenV4.js';
 export * from './constants.js';
 export type { DeployTokenOptions } from './deployment/deploy.js';
 export * from './services/vanityAddress.js';
+export {
+  ROBINHOOD_BLOCK_GAS_LIMIT,
+  ROBINHOOD_WETH_ADDRESS,
+  robinhood,
+} from './utils/chains/robinhood.js';
 export * from './utils/clankers.js';
 export * from './utils/market-cap.js';
 export {

--- a/src/utils/chains/robinhood.ts
+++ b/src/utils/chains/robinhood.ts
@@ -1,0 +1,32 @@
+import { defineChain } from 'viem';
+
+// Viem doesn't define `robinhood` yet. Once it does remove this definition.
+export const robinhood = /*#__PURE__*/ defineChain({
+  id: 4663,
+  name: 'Robinhood Chain',
+  blockTime: 100,
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.mainnet.chain.robinhood.com'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Robinhood Chain Blockscout Explorer',
+      url: 'https://robinhoodchain.blockscout.com',
+    },
+  },
+  contracts: {},
+  testnet: false,
+});
+
+/** Robinhood Chain block gas limit (2^50). */
+export const ROBINHOOD_BLOCK_GAS_LIMIT = 1_125_899_906_842_624n;
+
+/** Canonical WETH on Robinhood Chain (non-standard; not the OP predeploy). */
+export const ROBINHOOD_WETH_ADDRESS: `0x${string}` = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73';

--- a/src/utils/clankers.ts
+++ b/src/utils/clankers.ts
@@ -31,6 +31,7 @@ import {
 } from '../abi/v4.1.mainnet/ClankerToken.js';
 import { ClankerToken_v4_monad_bytecode } from '../abi/v4.1.monad/ClankerToken.js';
 import { monad } from './chains/monad.js';
+import { robinhood } from './chains/robinhood.js';
 
 type RelatedV0 = undefined;
 
@@ -327,6 +328,28 @@ export const CLANKERS = {
       feeStaticHookV2: '0xC5d309026BCAb6630888d51CE21154AD2f4828cC',
       feeDynamicHook: '0x0000000000000000000000000000000000000000',
       feeDynamicHookV2: '0x011a8ed40095F2D7E9c19125B8254b19678D68Cc',
+    } satisfies RelatedV4,
+  },
+  clanker_v4_robinhood: {
+    abi: Clanker_v4_abi,
+    token: {
+      abi: ClankerToken_v4_abi,
+      bytecode: ClankerToken_v4_bytecode,
+    },
+    chainId: robinhood.id,
+    type: 'clanker_v4',
+    address: '0xD3f2cC1731b7Fd17f28798835C2E02f0a1839A94',
+    related: {
+      locker: '0x290F735F63824BB5836cDe24a35F5103A5B5Bc99',
+      vault: '0x99B2a80ed21c7af1F5cc1A97383DADeEC7DD1427',
+      airdrop: '0x6f27372FF493A3855E6746b9a4fe6Ed2Cc3034B5',
+      devbuy: '0xa27b1986e5c7e5371Cb6507f87918fBD0302fF5a',
+      mevModule: '0xEA1Fe197dF140e5d88fC6B49f2d21Ea05092299e',
+      feeLocker: '0x88db2340bE5991B2b5Fca2Baee39B5CE048Cd70c',
+      feeStaticHook: '0x0000000000000000000000000000000000000000',
+      feeStaticHookV2: '0x48B8F6AD3A1b4aA477314c9a23035b8F84dDe8cc',
+      feeDynamicHook: '0x0000000000000000000000000000000000000000',
+      feeDynamicHookV2: '0x65efDF8Cce99b53C925DF878Df275Df21cB6E8Cc',
     } satisfies RelatedV4,
   },
 } as const satisfies Record<string, ClankerDeployment>;

--- a/src/utils/clankers.ts
+++ b/src/utils/clankers.ts
@@ -64,6 +64,8 @@ export type RelatedV4 = {
   presaleAllowlist?: `0x${string}`;
 
   mevModuleV2?: `0x${string}`;
+  /** Uses ClankerMevDescendingFees (requires encoded FeeConfig in mevModuleData). */
+  mevDescendingFees?: boolean;
   feeStaticHookV2?: `0x${string}`;
   feeDynamicHookV2?: `0x${string}`;
 };
@@ -345,6 +347,7 @@ export const CLANKERS = {
       airdrop: '0x6f27372FF493A3855E6746b9a4fe6Ed2Cc3034B5',
       devbuy: '0xa27b1986e5c7e5371Cb6507f87918fBD0302fF5a',
       mevModule: '0xEA1Fe197dF140e5d88fC6B49f2d21Ea05092299e',
+      mevDescendingFees: true,
       feeLocker: '0x88db2340bE5991B2b5Fca2Baee39B5CE048Cd70c',
       feeStaticHook: '0x0000000000000000000000000000000000000000',
       feeStaticHookV2: '0x48B8F6AD3A1b4aA477314c9a23035b8F84dDe8cc',

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -18,6 +18,7 @@ import {
   POOL_POSITIONS,
   WETH_ADDRESSES,
 } from '../../src/constants.js';
+import { robinhood } from '../../src/utils/chains/robinhood.js';
 import {
   getTickFromMarketCap,
   getTickFromMarketCapStable,
@@ -37,6 +38,7 @@ describe('CLI chain utilities', () => {
     expect(CHAIN_NAMES).toContain('bsc');
     expect(CHAIN_NAMES).toContain('unichain');
     expect(CHAIN_NAMES).toContain('monad');
+    expect(CHAIN_NAMES).toContain('robinhood');
     expect(CHAIN_NAMES).not.toContain('abstract');
   });
 
@@ -61,6 +63,7 @@ describe('CLI chain utilities', () => {
     expect(resolveChainId('bsc')).toBe(56);
     expect(resolveChainId('unichain')).toBe(130);
     expect(resolveChainId('monad')).toBe(143);
+    expect(resolveChainId('robinhood')).toBe(robinhood.id);
     expect(resolveChainId('abstract')).toBe(8453);
   });
 
@@ -69,7 +72,7 @@ describe('CLI chain utilities', () => {
   });
 
   test('resolveChain and resolveChainId are consistent', () => {
-    for (const name of ['base', 'arbitrum', 'ethereum', 'bsc', 'unichain']) {
+    for (const name of CHAIN_NAMES) {
       expect(resolveChain(name).id).toBe(resolveChainId(name));
     }
   });
@@ -175,6 +178,17 @@ describe('buildV4Config', () => {
     });
 
     expect(config.chainId).toBe(42161);
+  });
+
+  test('config with robinhood chain', () => {
+    const config = buildV4Config({
+      name: 'TestToken',
+      symbol: 'TST',
+      tokenAdmin: ADMIN,
+      chain: 'robinhood',
+    });
+
+    expect(config.chainId).toBe(robinhood.id);
   });
 
   test('config with DynamicBasic fees', () => {

--- a/test/tokens/v4/clankerV4Token.config.test.ts
+++ b/test/tokens/v4/clankerV4Token.config.test.ts
@@ -10,6 +10,7 @@ import { Clanker_MevSniperAuction_InitData_v4_1_abi } from '../../../src/abi/v4.
 import { Clanker_PoolInitializationData_v4_1_abi } from '../../../src/abi/v4.1/ClankerPool.js';
 import { clankerTokenV4Converter } from '../../../src/config/clankerTokenV4.js';
 import { CLANKERS, FEE_CONFIGS, POOL_POSITIONS, WETH_ADDRESSES } from '../../../src/index.js';
+import { robinhood } from '../../../src/utils/chains/robinhood.js';
 
 test('basic', async () => {
   const admin = '0x746d5412345883b0a4310181DCca3002110967B3';
@@ -259,4 +260,25 @@ test('vanity', async () => {
   expect(tx.value).toEqual(BigInt(3.2 * 1e18));
   expect(tx.expectedAddress?.toLowerCase()).toEndWith('b07');
   expect(tx.chainId).toEqual(8453);
+});
+
+test('robinhood', async () => {
+  const admin = '0x746d5412345883b0a4310181DCca3002110967B3';
+  const tx = await clankerTokenV4Converter({
+    name: 'TheName',
+    symbol: 'SYM',
+    tokenAdmin: admin,
+    chainId: robinhood.id,
+  });
+
+  expect(tx.address).toEqual(CLANKERS.clanker_v4_robinhood.address);
+  expect(tx.args?.[0]?.poolConfig?.pairedToken).toEqual(WETH_ADDRESSES[robinhood.id]);
+  expect(tx.args?.[0]?.lockerConfig?.locker).toEqual(CLANKERS.clanker_v4_robinhood.related.locker);
+  expect(tx.args?.[0]?.poolConfig?.hook).toEqual(
+    CLANKERS.clanker_v4_robinhood.related.feeStaticHookV2
+  );
+  expect(tx.args?.[0]?.mevModuleConfig?.mevModule).toEqual(
+    CLANKERS.clanker_v4_robinhood.related.mevModule
+  );
+  expect(tx.chainId).toEqual(robinhood.id);
 });

--- a/test/tokens/v4/clankerV4Token.config.test.ts
+++ b/test/tokens/v4/clankerV4Token.config.test.ts
@@ -280,5 +280,6 @@ test('robinhood', async () => {
   expect(tx.args?.[0]?.mevModuleConfig?.mevModule).toEqual(
     CLANKERS.clanker_v4_robinhood.related.mevModule
   );
+  expect(tx.args?.[0]?.mevModuleConfig?.mevModuleData).not.toEqual('0x');
   expect(tx.chainId).toEqual(robinhood.id);
 });


### PR DESCRIPTION
## Summary
- Adds Robinhood Chain (chain ID 4663) viem chain definition with RPC, explorer, block gas limit, and canonical WETH
- Adds official `clanker_v4_robinhood` deployment from `contracts/network_envs/robinhood-mainnet.env`
- Wires CLI chain support and exports `robinhood`, `ROBINHOOD_WETH_ADDRESS`, `ROBINHOOD_BLOCK_GAS_LIMIT`

## Official deployment (`clanker_v4_robinhood`)
| Contract | Address |
|---|---|
| Clanker | `0xD3f2cC1731b7Fd17f28798835C2E02f0a1839A94` |
| FeeLocker | `0x88db2340bE5991B2b5Fca2Baee39B5CE048Cd70c` |
| Vault | `0x99B2a80ed21c7af1F5cc1A97383DADeEC7DD1427` |
| AirdropV2 | `0x6f27372FF493A3855E6746b9a4fe6Ed2Cc3034B5` |
| DevBuy | `0xa27b1986e5c7e5371Cb6507f87918fBD0302fF5a` |
| LpLockerFeeConversion | `0x290F735F63824BB5836cDe24a35F5103A5B5Bc99` |
| HookStaticFeeV2 | `0x48B8F6AD3A1b4aA477314c9a23035b8F84dDe8cc` |
| HookDynamicFeeV2 | `0x65efDF8Cce99b53C925DF878Df275Df21cB6E8Cc` |
| MevFeeDecay | `0xEA1Fe197dF140e5d88fC6B49f2d21Ea05092299e` |

WETH: `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73`

## Test plan
- [x] `npm run lint` passes
- [x] Config test for Robinhood deploy args
- [x] Official contracts verified on-chain via RPC (bytecode present, factory not deprecated)
- [ ] E2E simulate once factory extensions are enabled on mainnet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain deploy calldata (MEV module init) and new chain-specific contract addresses; incorrect wiring would break Robinhood deploys but scope is additive with targeted tests.
> 
> **Overview**
> Adds **Robinhood Chain** (chain ID **4663**) end-to-end: custom viem `defineChain`, canonical WETH, public RPC in CLI setup, and a **`clanker_v4_robinhood`** deployment with official factory/extension addresses.
> 
> CLI deploy chain resolution no longer uses a partial hardcoded map—**`resolveChainId`** delegates to **`resolveChain`**, so **`--chain robinhood`** resolves to 4663 instead of defaulting to Base. SDK exports **`robinhood`**, **`ROBINHOOD_WETH_ADDRESS`**, and **`ROBINHOOD_BLOCK_GAS_LIMIT`**.
> 
> V4 deploy encoding now sets **`mevModuleData`** when a deployment has **`mevDescendingFees`** (Robinhood uses **ClankerMevDescendingFees** without **`mevModuleV2`**), fixing empty init data on Robinhood deploys. Tests cover CLI chain ID, config build, and converter output for Robinhood.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925a16f524e61054e20b4a2610c3a3ff5202e67c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->