### PR TITLE
Fix Robinhood v4 address prediction and vanity for 0x4b07 suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Clanker SDK - Changelog
 
+4.2.18
+- (Bug) Fix Robinhood v4 CREATE2 address prediction by using the correct ClankerToken creation bytecode (shared with BSC v4.1)
+
 4.2.17
 - (Chain) Robinhood Chain (chain ID 4663) with official v4 deployment addresses
 - (Bug) Fix CLI deploy chain resolution for Robinhood (`--chain robinhood` no longer defaults to Base)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clanker-sdk",
-  "version": "4.2.17",
+  "version": "4.2.18",
   "description": "SDK for deploying tokens using Clanker",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/utils/clankers.ts
+++ b/src/utils/clankers.ts
@@ -336,7 +336,8 @@ export const CLANKERS = {
     abi: Clanker_v4_abi,
     token: {
       abi: ClankerToken_v4_abi,
-      bytecode: ClankerToken_v4_bytecode,
+      // Robinhood mainnet deploys the same ClankerToken creation bytecode as BSC v4.1.
+      bytecode: ClankerToken_v4_bsc_bytecode,
     },
     chainId: robinhood.id,
     type: 'clanker_v4',

--- a/test/tokens/v4/clankerV4Token.config.test.ts
+++ b/test/tokens/v4/clankerV4Token.config.test.ts
@@ -295,7 +295,7 @@ test('robinhood vanity', async () => {
   });
 
   expect(tx.address).toEqual(CLANKERS.clanker_v4_robinhood.address);
-  expect(tx.expectedAddress?.toLowerCase()).toEndWith('4b07');
+  expect(tx.expectedAddress?.toLowerCase()).toEndWith('b07');
   expect(tx.args?.[0]?.tokenConfig.salt).toMatch(/^0x[a-fA-F0-9]{64}$/);
   expect(tx.chainId).toEqual(robinhood.id);
 });

--- a/test/tokens/v4/clankerV4Token.config.test.ts
+++ b/test/tokens/v4/clankerV4Token.config.test.ts
@@ -283,3 +283,19 @@ test('robinhood', async () => {
   expect(tx.args?.[0]?.mevModuleConfig?.mevModuleData).not.toEqual('0x');
   expect(tx.chainId).toEqual(robinhood.id);
 });
+
+test('robinhood vanity', async () => {
+  const admin = '0x746d5412345883b0a4310181DCca3002110967B3';
+  const tx = await clankerTokenV4Converter({
+    name: 'TheName',
+    symbol: 'SYM',
+    tokenAdmin: admin,
+    chainId: robinhood.id,
+    vanity: true,
+  });
+
+  expect(tx.address).toEqual(CLANKERS.clanker_v4_robinhood.address);
+  expect(tx.expectedAddress?.toLowerCase()).toEndWith('b07');
+  expect(tx.args?.[0]?.tokenConfig.salt).toMatch(/^0x[a-fA-F0-9]{64}$/);
+  expect(tx.chainId).toEqual(robinhood.id);
+});

--- a/test/tokens/v4/clankerV4Token.config.test.ts
+++ b/test/tokens/v4/clankerV4Token.config.test.ts
@@ -295,7 +295,7 @@ test('robinhood vanity', async () => {
   });
 
   expect(tx.address).toEqual(CLANKERS.clanker_v4_robinhood.address);
-  expect(tx.expectedAddress?.toLowerCase()).toEndWith('b07');
+  expect(tx.expectedAddress?.toLowerCase()).toEndWith('4b07');
   expect(tx.args?.[0]?.tokenConfig.salt).toMatch(/^0x[a-fA-F0-9]{64}$/);
   expect(tx.chainId).toEqual(robinhood.id);
 });

--- a/test/tokens/v4/predictTokenAddressFixtures.test.ts
+++ b/test/tokens/v4/predictTokenAddressFixtures.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test';
+import type { Hex } from 'viem';
+import { base } from 'viem/chains';
+import { ClankerToken_v4_abi, ClankerToken_v4_bytecode } from '../../../src/abi/v4/ClankerToken.js';
+import { ClankerToken_v4_bsc_bytecode } from '../../../src/abi/v4.1.bsc/ClankerToken.js';
+import { DEFAULT_SUPPLY } from '../../../src/constants.js';
+import { clankerConfigFor, predictTokenAddressV4 } from '../../../src/index.js';
+import { robinhood } from '../../../src/utils/chains/robinhood.js';
+
+describe('predictTokenAddressV4 on-chain fixtures', () => {
+  const robinhoodConfig = clankerConfigFor(robinhood.id, 'clanker_v4');
+  const baseConfig = clankerConfigFor(base.id, 'clanker_v4');
+  if (!robinhoodConfig || !baseConfig) throw new Error('Config not found');
+
+  it('uses Robinhood/BSC token bytecode for CREATE2 prediction', () => {
+    expect(robinhoodConfig.token.bytecode).toBe(ClankerToken_v4_bsc_bytecode);
+    expect(robinhoodConfig.token.bytecode).not.toBe(ClankerToken_v4_bytecode);
+  });
+
+  it('matches Robinhood incident deploy tx (0xab51d3e1...)', () => {
+    const tokenAdmin = '0x71cbbe6eCf1a9C4d8b9115757eBcC5Ff45902177' as const;
+    const salt = '0x00000000000000000000000000000000f9da93237c8b2af1b9887f87a902fffa' as Hex;
+    const args = [
+      'clankerwifhood',
+      'clwifhood',
+      DEFAULT_SUPPLY,
+      tokenAdmin,
+      'https://imagedelivery.net/BXluQx4ige9GuW0Ia56BHw/377b8283-404e-425b-d569-e28016088f00/original',
+      '',
+      '{"interface":"clanker","platform":"farcaster","messageId":"0x680df66f6e64537a09c457bdb2ff399aa383f108","id":"527771"}',
+      BigInt(robinhood.id),
+    ] as const;
+
+    const predicted = predictTokenAddressV4(args, robinhoodConfig, salt, tokenAdmin);
+
+    expect(predicted).toBe('0x085844F1E613f61e206df92A9Bf1Ceb75aF113b5');
+    expect(predicted).not.toBe('0x75b45af4D5AB4B0bb5ceE0aC5E87293e23231B07');
+  });
+
+  it('keeps Base on generic v4 bytecode with stable prediction', () => {
+    expect(baseConfig.token.bytecode).toBe(ClankerToken_v4_bytecode);
+    expect(baseConfig.token.abi).toBe(ClankerToken_v4_abi);
+
+    const tokenAdmin = '0x71cbbe6eCf1a9C4d8b9115757eBcC5Ff45902177' as const;
+    const salt = '0x00000000000000000000000000000000f9da93237c8b2af1b9887f87a902fffa' as Hex;
+    const args = [
+      'clankerwifhood',
+      'clwifhood',
+      DEFAULT_SUPPLY,
+      tokenAdmin,
+      'https://imagedelivery.net/BXluQx4ige9GuW0Ia56BHw/377b8283-404e-425b-d569-e28016088f00/original',
+      '',
+      '{"interface":"clanker","platform":"farcaster","messageId":"0x680df66f6e64537a09c457bdb2ff399aa383f108","id":"527771"}',
+      BigInt(base.id),
+    ] as const;
+
+    const predicted = predictTokenAddressV4(args, baseConfig, salt, tokenAdmin);
+
+    expect(predicted).toBe('0xAf3edBDb6A0D7434179E56f3A77CCB72a492F9D1');
+  });
+});


### PR DESCRIPTION
## Summary
- Point `clanker_v4_robinhood` at the BSC v4.1 `ClankerToken` creation bytecode so CREATE2 prediction matches on-chain Robinhood deploys.
- Fixes the incident mismatch where SDK predicted `0x75b45af4...` but the actual token was `0x085844F1...`.
- Ensures vanity search (`init_code_hash`) and `predictTokenAddressV4` stay in sync for Robinhood `0x4b07` suffix addresses.

## Test plan
- [x] `predictTokenAddressV4` matches Robinhood incident deploy tx fixture (`0xab51d3e1...` → `0x085844F1...`)
- [x] Live vanity service returns `...4b07` and prediction matches returned address
- [x] Base config still uses generic v4 bytecode (regression guard)
- [ ] Merge and publish `4.2.18` to npm


Made with [Cursor](https://cursor.com)